### PR TITLE
UI enhancements and minor corrections

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -57,7 +57,10 @@
             $(document).ajaxError(
                 function (event, request, settings, errorThrown) {
 
-                viewModel.errors.push({ message: errorThrown });
+                viewModel.errors.push({
+                    message: "[" + event.type + ": " + request.statusText + "]"
+                           + " Error requesting " + settings.url
+                           + " " + errorThrown });
             });
 
             ko.applyBindings(viewModel);

--- a/static/index.html
+++ b/static/index.html
@@ -25,7 +25,7 @@
 
             <thead>
                 <tr>
-                    <th>Message type</th>
+                    <th>Event type</th>
                     <th>Total in last complete hour</th>
                     <th>Total in last complete day</th>
                 </tr>
@@ -67,7 +67,7 @@
 
             var cubeBaseUrl = "http://eventcube.red-gate.com/1.0/";
 
-            var getLastMessageUrl = function (type) {
+            var getLastEventUrl = function (type) {
 
                 var parameters = {
                     expression: type + "(payload,headers,messageType)",
@@ -89,9 +89,9 @@
 
                 types = types.filter(function (type) {
 
-                    var ignoredMessageTypes = ["cube_compute", "cube_request"];
+                    var ignoredEventTypes = ["cube_compute", "cube_request"];
 
-                    return ignoredMessageTypes.indexOf(type) === -1;
+                    return ignoredEventTypes.indexOf(type) === -1;
                 });
 
                 types.forEach(function (typeName) {
@@ -101,7 +101,7 @@
                         type: {
 
                             value: typeName,
-                            url:   getLastMessageUrl(typeName)
+                            url:   getLastEventUrl(typeName)
                         },
 
                         totalInLastCompletedHour: {

--- a/static/index.html
+++ b/static/index.html
@@ -33,7 +33,9 @@
 
             <tbody data-bind="foreach: types">
                 <tr>
-                    <td data-bind="text: name" />
+                    <td data-bind="with: type">
+                        <a data-bind="text: value, attr: { href: url }" />
+                    </td>
                     <td data-bind="with: totalInLastCompletedHour">
                         <a data-bind="text: value, attr: { href: url }" />
                     </td>
@@ -62,6 +64,15 @@
 
             var cubeBaseUrl = "http://eventcube.red-gate.com/1.0/";
 
+            var getLastMessageUrl = function (type) {
+
+                var parameters = {
+                    expression: type + "(payload,headers,messageType)",
+                    limit:      1 };
+
+                return cubeBaseUrl + "event?" + $.param(parameters);
+            };
+
             var getTotalMetricUrl = function (type, period, limit) {
 
                 var parameters = { expression: "sum(" + type + ")",
@@ -84,7 +95,11 @@
 
                     var typeData = {
 
-                        name: typeName,
+                        type: {
+
+                            value: typeName,
+                            url:   getLastMessageUrl(typeName)
+                        },
 
                         totalInLastCompletedHour: {
 

--- a/static/index.html
+++ b/static/index.html
@@ -73,7 +73,7 @@
                 return cubeBaseUrl + "event?" + $.param(parameters);
             };
 
-            var getTotalMetricUrl = function (type, period, limit) {
+            var getTotalMetricsUrl = function (type, period, limit) {
 
                 var parameters = { expression: "sum(" + type + ")",
                                    step:       period,
@@ -104,25 +104,25 @@
                         totalInLastCompletedHour: {
 
                             value: ko.observable('...'),
-                            url:   getTotalMetricUrl(typeName, '36e5', 5)
+                            url:   getTotalMetricsUrl(typeName, '36e5', 5)
                         },
 
                         totalInLastCompletedDay: {
 
                             value: ko.observable('...'),
-                            url:   getTotalMetricUrl(typeName, '864e5', 5)
+                            url:   getTotalMetricsUrl(typeName, '864e5', 5)
                         }
                     };
 
                     viewModel.types.push(typeData);
 
-                    $.get(getTotalMetricUrl(typeName, '36e5', 1))
+                    $.get(getTotalMetricsUrl(typeName, '36e5', 1))
                      .then(function (response) {
 
                         typeData.totalInLastCompletedHour.value(response[0].value);
                     });
 
-                    $.get(getTotalMetricUrl(typeName, '864e5', 1))
+                    $.get(getTotalMetricsUrl(typeName, '864e5', 1))
                      .then(function (response) {
 
                         typeData.totalInLastCompletedDay.value(response[0].value);


### PR DESCRIPTION
- add links from the event type to the last event of that type
- show more detailed error messages (`errorThrown` is often empty)
  minor changes:
- rename `getTotalMetricsUrl` to reflect what it returns, fix terminology: use "event" instead of "message"
