### PR TITLE
add style and check if requested event has payload

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,9 @@
 
         <meta charset="utf-8">
 
+        <link rel="stylesheet"
+              href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
         <script src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
         <script src="http://knockoutjs.com/downloads/knockout-3.3.0.js"></script>
 
@@ -15,37 +18,41 @@
 
     <body>
 
-        <table data-bind="foreach: errors">
-            <tr>
-                <td data-bind="text: message" />
-            </tr>
-        </table>
+        <div class="container">
 
-        <table>
-
-            <thead>
+            <table data-bind="foreach: errors" class="table">
                 <tr>
-                    <th>Event type</th>
-                    <th>Total in last complete hour</th>
-                    <th>Total in last complete day</th>
+                    <td data-bind="text: message" class="danger" />
                 </tr>
-            </thead>
+            </table>
 
-            <tbody data-bind="foreach: types">
-                <tr>
-                    <td data-bind="with: type">
-                        <a data-bind="text: value, attr: { href: url }" />
-                    </td>
-                    <td data-bind="with: totalInLastCompletedHour">
-                        <a data-bind="text: value, attr: { href: url }" />
-                    </td>
-                    <td data-bind="with: totalInLastCompletedDay">
-                        <a data-bind="text: value, attr: { href: url }" />
-                    </td>
-                </tr>
-            </tbody>
+            <table class="table table-striped table-bordered table-hover">
 
-        </table>
+                <thead>
+                    <tr>
+                        <th>Event type</th>
+                        <th>Total in last complete hour</th>
+                        <th>Total in last complete day</th>
+                    </tr>
+                </thead>
+
+                <tbody data-bind="foreach: types">
+                    <tr>
+                        <td data-bind="with: type">
+                            <a data-bind="text: value, attr: { href: url }" />
+                        </td>
+                        <td data-bind="with: totalInLastCompletedHour">
+                            <a data-bind="text: value, attr: { href: url }" />
+                        </td>
+                        <td data-bind="with: totalInLastCompletedDay">
+                            <a data-bind="text: value, attr: { href: url }" />
+                        </td>
+                    </tr>
+                </tbody>
+
+            </table>
+
+        </div>
 
         <script>(function () { "use strict";
 

--- a/static/index.html
+++ b/static/index.html
@@ -31,8 +31,9 @@
                 <thead>
                     <tr>
                         <th>Event type</th>
-                        <th>Total in last complete hour</th>
-                        <th>Total in last complete day</th>
+                        <th>Total in last <abbr title="i.e. the number of events of this type that occurred in the hour before this one, from o'clock to o'clock
+e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> hour</th>
+                        <th>Total in last <abbr title="i.e. the number of events of this type that occurred yesterday, from midnight to midnight">complete*</abbr> day</th>
                     </tr>
                 </thead>
 

--- a/static/index.html
+++ b/static/index.html
@@ -139,44 +139,42 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
                 return cubeBaseUrl + "event?" + $.param(parameters);
             };
 
-            // This function checks if the event has a payload before requesting it.
-            // Not all event types have a payload - when we request the last
-            // heartbeat event using the expression heartbeat(payload,headers,messageType),
-            // Cube will slow down as it will try to search through all heartbeat
-            // messages since none of them has a payload.
+            // This function checks if the event has a payload before
+            // redirecting. Not all event types have a payload e.g. heartbeats.
+            // If we requested the last heartbeat event using the expression
+            // heartbeat(payload,headers,messageType) Square cube would try to
+            // find a heartbeat with a payload by inspecting all heartbeats ever.
+            // That would be very slow.
+            //
             redGate.redirectToLastEvent = function (type) {
 
-                // First obtain the time of the last event of this type
                 $.get(getEventUrl({ expression: type })).then(function (result) {
 
-                    // If there are no events at all, don't do anything
-                    if (result.length === 0) {
-                        return;
+                    var lastEventPlusPayloadFilter = {
+                        expression: type + "(payload)" };
+
+                    if (result.length !== 0) {
+
+                        lastEventPlusPayloadFilter.start = result[0].time;
                     }
 
-                    var tryPayload = {
-                        expression: type + "(payload,headers,messageType)",
-                        start:      result[0].time };
+                    $.get(getEventUrl(lastEventPlusPayloadFilter))
+                        .then(function (result) {
 
-                    // Then ask for the same event with a payload
-                    // The start time is the time of the last event, so cube won't
-                    // search through all the events in case this type of event
-                    // has no payload
-                    $.get(getEventUrl(tryPayload)).then(function (result) {
-
-                        var request;
+                        var lastEventWithDetailsFilter;
 
                         if (result.length > 0) {
-                            // the event has a payload, so we can safely retrieve it
-                            request = {
+
+                            lastEventWithDetailsFilter = {
                                 expression: type + "(payload,headers,messageType)" };
+
                         } else {
-                            // no event was returned, so the event has no payload
-                            request = {
+
+                            lastEventWithDetailsFilter = {
                                 expression: type + "(headers,messageType)" };
                         }
 
-                        location.href = getEventUrl(request);
+                        location.href = getEventUrl(lastEventWithDetailsFilter);
                     });
                 });
             };

--- a/static/index.html
+++ b/static/index.html
@@ -39,8 +39,8 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
 
                 <tbody data-bind="foreach: types">
                     <tr>
-                        <td data-bind="with: type">
-                            <a data-bind="text: value, attr: { href: url }" />
+                        <td>
+                            <a data-bind="text: typeName, attr: { href: 'javascript:redGate.redirectToLastEvent(\'' + typeName + '\')' }" />
                         </td>
                         <td data-bind="with: totalInLastCompletedHour">
                             <a data-bind="text: value, attr: { href: url }" />
@@ -55,7 +55,11 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
 
         </div>
 
-        <script>(function () { "use strict";
+        <script>
+
+        var redGate = {};
+
+        (function () { "use strict";
 
             $.support.cors = true;
 
@@ -74,15 +78,6 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
             ko.applyBindings(viewModel);
 
             var cubeBaseUrl = "http://eventcube.red-gate.com/1.0/";
-
-            var getLastEventUrl = function (type) {
-
-                var parameters = {
-                    expression: type + "(payload,headers,messageType)",
-                    limit:      1 };
-
-                return cubeBaseUrl + "event?" + $.param(parameters);
-            };
 
             var getTotalMetricsUrl = function (type, period, limit) {
 
@@ -106,11 +101,7 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
 
                     var typeData = {
 
-                        type: {
-
-                            value: typeName,
-                            url:   getLastEventUrl(typeName)
-                        },
+                        typeName: typeName,
 
                         totalInLastCompletedHour: {
 
@@ -141,6 +132,54 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
                 });
             });
 
+            var getEventUrl = function (parameters) {
+
+                parameters.limit = 1;
+
+                return cubeBaseUrl + "event?" + $.param(parameters);
+            };
+
+            // This function checks if the event has a payload before requesting it.
+            // Not all event types have a payload - when we request the last
+            // heartbeat event using the expression heartbeat(payload,headers,messageType),
+            // Cube will slow down as it will try to search through all heartbeat
+            // messages since none of them has a payload.
+            redGate.redirectToLastEvent = function (type) {
+
+                // First obtain the time of the last event of this type
+                $.get(getEventUrl({ expression: type })).then(function (result) {
+
+                    // If there are no events at all, don't do anything
+                    if (result.length === 0) {
+                        return;
+                    }
+
+                    var tryPayload = {
+                        expression: type + "(payload,headers,messageType)",
+                        start:      result[0].time };
+
+                    // Then ask for the same event with a payload
+                    // The start time is the time of the last event, so cube won't
+                    // search through all the events in case this type of event
+                    // has no payload
+                    $.get(getEventUrl(tryPayload)).then(function (result) {
+
+                        var request;
+
+                        if (result.length > 0) {
+                            // the event has a payload, so we can safely retrieve it
+                            request = {
+                                expression: type + "(payload,headers,messageType)" };
+                        } else {
+                            // no event was returned, so the event has no payload
+                            request = {
+                                expression: type + "(headers,messageType)" };
+                        }
+
+                        location.href = getEventUrl(request);
+                    });
+                });
+            };
         }());</script>
 
     </body>


### PR DESCRIPTION
- add Bootstrap stylesheet and tooltips
- check if the event type has a payload before requesting it to avoid slowing down square cube (There seems to be no way of retrieving the complete data field of an event.)
