### PR TITLE
display time periods in column headers and other minor changes

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -109,7 +109,7 @@
 
             <div class="hint">
                 <p class="summary">Example event query with a filter over headers</p>
-                <a href="http://eventcube.red-gate.com/1.0/event?expression=error(payload).eq(headers.appName,'RedGate.Internal.RedGateToSalesforce.Service').eq(headers.log_level,'Error')&amp;start=2015-07-18T00:00:00Z&amp;stop=2015-07-20T00:00:00Z">
+                <a href="http://eventcube.red-gate.com/1.0/event?expression=error(payload).eq(headers.appName,'RedGate.Internal.RedGateToSalesforce.Service').eq(headers.log_level,'Error')&start=2015-07-18T00:00:00Z&stop=2015-07-20T00:00:00Z">
                     error(payload).eq(headers.appName,'RedGate.Internal.RedGateToSalesforce.Service').eq(headers.log_level,'Error')&amp;start=2015-07-18T00:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">Note that multiple filters can be applied, here we're using two .eq filters and a date range.
@@ -119,7 +119,7 @@
 
             <div class="hint">
                 <p class="summary">Example event query with sub-string filter over payload property</p>
-                <a href="http://eventcube.red-gate.com/1.0/event?expression=download_started(payload).re(payload.productName,'SQL')&amp;start=2015-07-19T22:00:00Z&amp;stop=2015-07-20T00:00:00Z">
+                <a href="http://eventcube.red-gate.com/1.0/event?expression=download_started(payload).re(payload.productName,'SQL')&start=2015-07-19T22:00:00Z&stop=2015-07-20T00:00:00Z">
                     download_started(payload).re(payload.productName,'SQL')&amp;start=2015-07-19T22:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">The .re filter is a actually a regular expression filter, but without any regex syntax it acts as a sub-string filter.</p>
@@ -127,7 +127,7 @@
 
             <div class="hint">
                 <p class="summary">Example metric query</p>
-                <a href="http://eventcube.red-gate.com/1.0/metric?expression=distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine%20country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z">
+                <a href="http://eventcube.red-gate.com/1.0/metric?expression=distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&step=864e5&start=2015-07-15T00:00:00Z&stop=2015-07-20T00:00:00Z">
                     distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">This queries for the number of IP addresses where we failed to discern the country to work-out whether they're embargoed per day.

--- a/static/index.html
+++ b/static/index.html
@@ -127,7 +127,7 @@
 
             <div class="hint">
                 <p class="summary">Example metric query</p>
-                <a href="http://eventcube.red-gate.com/1.0/metric?expression=distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z">
+                <a href="http://eventcube.red-gate.com/1.0/metric?expression=distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine%20country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z">
                     distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">This queries for the number of IP addresses where we failed to discern the country to work-out whether they're embargoed per day.

--- a/static/index.html
+++ b/static/index.html
@@ -16,6 +16,13 @@
 
         <style>
 
+            .period
+            {
+                font-size: 0.7em;
+                color: grey;
+                font-weight: normal;
+            }
+
             .hint .summary
             {
                 font-weight: bold;
@@ -52,9 +59,20 @@
                 <thead>
                     <tr>
                         <th>Event type</th>
-                        <th>Total in last <abbr title="i.e. the number of events of this type that occurred in the hour before this one, from o'clock to o'clock
-e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> hour</th>
-                        <th>Total in last <abbr title="i.e. the number of events of this type that occurred yesterday, from midnight to midnight">complete*</abbr> day</th>
+                        <th data-bind="with: hourPeriod">
+                            Total in last complete hour
+                            <div class="period">
+                                <span data-bind="text: start"></span>
+                                to <span data-bind="text: end" ></span>
+                            </div>
+                        </th>
+                        <th data-bind="with: dayPeriod">
+                            Total in last complete day<br/>
+                            <div class="period">
+                                <span data-bind="text: start"></span>
+                                to <span data-bind="text: end" ></span>
+                            </div>
+                        </th>
                     </tr>
                 </thead>
 
@@ -147,7 +165,11 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
 
             $.support.cors = true;
 
-            var viewModel = { types:  ko.observableArray(),
+            var viewModel = { hourPeriod: { start: ko.observable('...'),
+                                            end:   ko.observable('...') },
+                              dayPeriod:  { start: ko.observable('...'),
+                                            end:   ko.observable('...') },
+                              types:  ko.observableArray(),
                               errors: ko.observableArray() };
 
             $(document).ajaxError(
@@ -171,6 +193,39 @@ e.g. if it's 5:30 then this shows the total from 4:00 to 5:00">complete*</abbr> 
 
                 return cubeBaseUrl + "metric?" + $.param(parameters);
             };
+
+            var populateViewModelWithPeriod = function(stepping,
+                                                       viewModelPeriod,
+                                                       addPeriod) {
+
+                // We query a non-existing event type here as all
+                // we want is the start time of the last complete
+                // period for the corresponding stepping from square cube
+                //
+                $.get(getTotalMetricsUrl('fakeEventType', stepping, 1))
+                 .then(function (response) {
+
+                    var start = new Date(response[0].time);
+
+                    viewModelPeriod.start(start.toISOString());
+
+                    var end = new Date(start);
+
+                    addPeriod(end);
+
+                    viewModelPeriod.end(end.toISOString());
+                });
+            };
+
+            populateViewModelWithPeriod(
+                '36e5',
+                viewModel.hourPeriod,
+                function (t) { t.setHours(t.getHours() + 1); });
+
+            populateViewModelWithPeriod(
+                '864e5',
+                viewModel.dayPeriod,
+                function (t) { t.setDate(t.getDate() + 1); });
 
             $.get(cubeBaseUrl + "types").then(function (types) {
 

--- a/static/index.html
+++ b/static/index.html
@@ -245,13 +245,13 @@
                         totalInLastCompletedHour: {
 
                             value: ko.observable('...'),
-                            url:   getTotalMetricsUrl(typeName, '36e5', 5)
+                            url:   getTotalMetricsUrl(typeName, '36e5', 10)
                         },
 
                         totalInLastCompletedDay: {
 
                             value: ko.observable('...'),
-                            url:   getTotalMetricsUrl(typeName, '864e5', 5)
+                            url:   getTotalMetricsUrl(typeName, '864e5', 10)
                         }
                     };
 

--- a/static/index.html
+++ b/static/index.html
@@ -151,7 +151,7 @@
             <div class="hint">
                 <p class="summary">Querying for absent properties</p>
                 <p class="description">Sadly there is no filter in square cube that allows you to include only events where a certain property is null or absent.
-                    Performing an event query which will return a property will only return those events which actually have that property, others will not be omitted.
+                    Performing an event query which will return a property will only return those events which actually have that property, others will be omitted.
                     e.g. example(payload) will only return example events which actually have a payload.</p>
             </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -109,7 +109,7 @@
 
             <div class="hint">
                 <p class="summary">Example event query with a filter over headers</p>
-                <a href="http://eventcube.red-gate.com/1.0/event?expression=error(payload).eq(headers.appName,'RedGate.Internal.RedGateToSalesforce.Service').eq(headers.log_level,'Error')&start=2015-07-18T00:00:00Z&stop=2015-07-20T00:00:00Z">
+                <a href="http://eventcube.red-gate.com/1.0/event?expression=error(payload).eq(headers.appName,'RedGate.Internal.RedGateToSalesforce.Service').eq(headers.log_level,'Error')&amp;start=2015-07-18T00:00:00Z&amp;stop=2015-07-20T00:00:00Z">
                     error(payload).eq(headers.appName,'RedGate.Internal.RedGateToSalesforce.Service').eq(headers.log_level,'Error')&amp;start=2015-07-18T00:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">Note that multiple filters can be applied, here we're using two .eq filters and a date range.
@@ -119,7 +119,7 @@
 
             <div class="hint">
                 <p class="summary">Example event query with sub-string filter over payload property</p>
-                <a href="http://eventcube.red-gate.com/1.0/event?expression=download_started(payload).re(payload.productName,'SQL')&start=2015-07-19T22:00:00Z&stop=2015-07-20T00:00:00Z">
+                <a href="http://eventcube.red-gate.com/1.0/event?expression=download_started(payload).re(payload.productName,'SQL')&amp;start=2015-07-19T22:00:00Z&amp;stop=2015-07-20T00:00:00Z">
                     download_started(payload).re(payload.productName,'SQL')&amp;start=2015-07-19T22:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">The .re filter is a actually a regular expression filter, but without any regex syntax it acts as a sub-string filter.</p>
@@ -127,7 +127,7 @@
 
             <div class="hint">
                 <p class="summary">Example metric query</p>
-                <a href="http://eventcube.red-gate.com/1.0/metric?expression=distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&step=864e5&start=2015-07-15T00:00:00Z&stop=2015-07-20T00:00:00Z">
+                <a href="http://eventcube.red-gate.com/1.0/metric?expression=distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z">
                     distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">This queries for the number of IP addresses where we failed to discern the country to work-out whether they're embargoed per day.

--- a/static/index.html
+++ b/static/index.html
@@ -120,7 +120,7 @@
             <div class="hint">
                 <p class="summary">Example event query with sub-string filter over payload property</p>
                 <a href="http://eventcube.red-gate.com/1.0/event?expression=download_started(payload).re(payload.productName,'SQL')&start=2015-07-19T22:00:00Z&stop=2015-07-20T00:00:00Z">
-                    download_started(payload).re(payload.productName,'SQL')&start=2015-07-19T22:00:00Z&stop=2015-07-20T00:00:00Z
+                    download_started(payload).re(payload.productName,'SQL')&amp;start=2015-07-19T22:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">The .re filter is a actually a regular expression filter, but without any regex syntax it acts as a sub-string filter.</p>
             </div>
@@ -128,7 +128,7 @@
             <div class="hint">
                 <p class="summary">Example metric query</p>
                 <a href="http://eventcube.red-gate.com/1.0/metric?expression=distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&step=864e5&start=2015-07-15T00:00:00Z&stop=2015-07-20T00:00:00Z">
-                    distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&step=864e5&start=2015-07-15T00:00:00Z&stop=2015-07-20T00:00:00Z
+                    distinct(embargoing_failure(payload.ipAddress).re(payload.message,'determine country'))&amp;step=864e5&amp;start=2015-07-15T00:00:00Z&amp;stop=2015-07-20T00:00:00Z
                 </a>
                 <p class="description">This queries for the number of IP addresses where we failed to discern the country to work-out whether they're embargoed per day.
                     The full list of <a href="https://github.com/square/cube/wiki/Queries#reduces">roll-up methods available are described here</a>.


### PR DESCRIPTION
- show the UTC time periods of the metrics returned by square cube
- show more metrics
- escape & everywhere and space in URLs
- correct a typo
